### PR TITLE
Update test suite to work with Rspec 3 and newer ruby-saml

### DIFF
--- a/ruby-saml-idp.gemspec
+++ b/ruby-saml-idp.gemspec
@@ -24,10 +24,9 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.add_dependency('uuid')
   s.add_development_dependency "rake"
-  # s.add_development_dependency "rcov"
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "ruby-saml"
+  s.add_development_dependency("rspec", "~> 3.0")
+  s.add_development_dependency("ruby-saml", "~> 0.8")
   s.add_development_dependency("rails", "~> 3.2")
-  s.add_development_dependency("capybara")
+  s.add_development_dependency("capybara", "~> 2.4.1")
 end
 

--- a/spec/acceptance/idp_controller_spec.rb
+++ b/spec/acceptance/idp_controller_spec.rb
@@ -9,8 +9,8 @@ feature 'IdpController' do
     fill_in 'Password', :with => "okidoki"
     click_button 'Sign in'
     click_button 'Submit'   # simulating onload
-    current_url.should == 'http://foo.example.com/saml/consume'
-    page.should have_content "brad.copa@example.com"
+    expect(current_url).to eq('http://foo.example.com/saml/consume')
+    expect(page).to have_content("brad.copa@example.com")
   end
 
 end

--- a/spec/rails_app/app/controllers/saml_controller.rb
+++ b/spec/rails_app/app/controllers/saml_controller.rb
@@ -1,7 +1,7 @@
 class SamlController < ApplicationController
 
   def consume
-    response = Onelogin::Saml::Response.new(params[:SAMLResponse])
+    response = OneLogin::RubySaml::Response.new(params[:SAMLResponse])
     render :text => response.name_id
   end
 

--- a/spec/saml_idp/controller_spec.rb
+++ b/spec/saml_idp/controller_spec.rb
@@ -12,7 +12,7 @@ describe SamlIdp::Controller do
     requested_saml_acs_url = "https://example.com/saml/consume"
     params[:SAMLRequest] = make_saml_request(requested_saml_acs_url)
     validate_saml_request
-    saml_acs_url.should == requested_saml_acs_url
+    expect(saml_acs_url).to eq(requested_saml_acs_url)
   end
 
   context "SAML Responses" do
@@ -23,22 +23,22 @@ describe SamlIdp::Controller do
 
     it "should create a SAML Response" do
       saml_response = encode_SAMLResponse("foo@example.com")
-      response = Onelogin::Saml::Response.new(saml_response)
-      response.name_id.should == "foo@example.com"
-      response.issuer.should == "http://example.com"
+      response = OneLogin::RubySaml::Response.new(saml_response)
+      expect(response.name_id).to eq("foo@example.com")
+      expect(response.issuer).to eq("http://example.com")
       response.settings = saml_settings
-      response.is_valid?.should be_true
+      expect(response.is_valid?).to be true
     end
 
     [:sha1, :sha256, :sha384, :sha512].each do |algorithm_name|
       it "should create a SAML Response using the #{algorithm_name} algorithm" do
         self.algorithm = algorithm_name
         saml_response = encode_SAMLResponse("foo@example.com")
-        response = Onelogin::Saml::Response.new(saml_response)
-        response.name_id.should == "foo@example.com"
-        response.issuer.should == "http://example.com"
+        response = OneLogin::RubySaml::Response.new(saml_response)
+        expect(response.name_id).to eq("foo@example.com")
+        expect(response.issuer).to eq("http://example.com")
         response.settings = saml_settings
-        response.is_valid?.should be_true
+        expect(response.is_valid?).to be true
       end
     end
   end

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -1,16 +1,16 @@
 module SamlRequestMacros
 
   def make_saml_request(requested_saml_acs_url = "https://foo.example.com/saml/consume")
-    auth_request = Onelogin::Saml::Authrequest.new
-    auth_url = auth_request.create(saml_settings(requested_saml_acs_url))
+    auth_request = OneLogin::RubySaml::Authrequest.new
+    auth_url = auth_request.create(saml_settings(saml_acs_url: requested_saml_acs_url))
     CGI.unescape(auth_url.split("=").last)
   end
 
-  def saml_settings(saml_acs_url = "https://foo.example.com/saml/consume")
-    settings = Onelogin::Saml::Settings.new
-    settings.assertion_consumer_service_url = saml_acs_url
-    settings.issuer = "http://example.com/issuer"
-    settings.idp_sso_target_url = "http://idp.com/saml/idp"
+  def saml_settings(options = {})
+    settings = OneLogin::RubySaml::Settings.new
+    settings.assertion_consumer_service_url = options[:saml_acs_url] || "https://foo.example.com/saml/consume"
+    settings.issuer = options[:issuer] || "http://example.com/issuer"
+    settings.idp_sso_target_url = options[:idp_sso_target_url] || "http://idp.com/saml/idp"
     settings.idp_cert_fingerprint = SamlIdp::Default::FINGERPRINT
     settings.name_identifier_format = SamlIdp::Default::NAME_ID_FORMAT
     settings


### PR DESCRIPTION
Since the last time that this gem was messed with the ruby-saml library
has changed from Onelogin::Saml to OneLogin::RubySaml. This updates the
uses of this gem to match the new namespace. It also updates the test
suite to work with rspec 3.0's "expect" syntax. In addition to this it
pins the gem versions so that the gems updating won't break the build
for anyone who might want to contribute to this project.
