### PR TITLE
Remove uuid gem in favor of SecureRandom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+before_install:
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
 branches:
   only:
     - master

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -5,7 +5,6 @@ module SamlIdp
     require 'openssl'
     require 'base64'
     require 'time'
-    require 'uuid'
 
     attr_accessor :x509_certificate, :secret_key, :algorithm
     attr_accessor :saml_acs_url
@@ -61,7 +60,7 @@ module SamlIdp
 
       def encode_SAMLResponse(nameID, opts = {})
         now = Time.now.utc
-        response_id, reference_id = UUID.generate, UUID.generate
+        response_id, reference_id = SecureRandom.uuid, SecureRandom.uuid
         audience_uri = opts[:audience_uri] || saml_acs_url[/^(.*?\/\/.*?\/)/, 1]
         issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "http://example.com"
         attributes_statement = attributes(opts[:attributes_provider], nameID)

--- a/ruby-saml-idp.gemspec
+++ b/ruby-saml-idp.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.rdoc_options = ["--charset=UTF-8"]
-  s.add_dependency('uuid')
   s.add_development_dependency "rake"
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("rspec", "~> 3.0")


### PR DESCRIPTION
Recent [update of ruby-saml](https://github.com/onelogin/ruby-saml/releases/tag/v1.2.0) dropped the dependency of uuid. Remove `uuid` gem from `ruby-saml-idp` to reduce a dependency for projects which use `ruby-saml-idp`
