### PR TITLE
Add optional session expiration information

### DIFF
--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -1,12 +1,13 @@
 # encoding: utf-8
 module SamlIdp
   class Configurator
-    attr_accessor :x509_certificate, :secret_key, :algorithm
+    attr_accessor :x509_certificate, :secret_key, :algorithm, :expires_in
 
     def initialize(config_file = nil)
       self.x509_certificate = Default::X509_CERTIFICATE
       self.secret_key = Default::SECRET_KEY
       self.algorithm = :sha1
+      self.expires_in = nil
       instance_eval(File.read(config_file), config_file) if config_file
     end
   end

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -6,7 +6,7 @@ module SamlIdp
     require 'base64'
     require 'time'
 
-    attr_accessor :x509_certificate, :secret_key, :algorithm
+    attr_accessor :x509_certificate, :secret_key, :algorithm, :expires_in
     attr_accessor :saml_acs_url
 
     def x509_certificate
@@ -43,6 +43,11 @@ module SamlIdp
       algorithm.to_s.split('::').last.downcase
     end
 
+    def expires_in
+      return @expires_in if defined?(@expires_in)
+      @expires_in = SamlIdp.config.expires_in
+    end
+
     protected
 
       def validate_saml_request(saml_request = params[:SAMLRequest])
@@ -65,7 +70,12 @@ module SamlIdp
         issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "http://example.com"
         attributes_statement = attributes(opts[:attributes_provider], nameID)
 
-        assertion = %[<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{reference_id}" IssueInstant="#{now.iso8601}" Version="2.0"><saml:Issuer Format="urn:oasis:names:SAML:2.0:nameid-format:entity">#{issuer_uri}</saml:Issuer><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">#{nameID}</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData InResponseTo="#{@saml_request_id}" NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_acs_url}"></saml:SubjectConfirmationData></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}"><saml:AudienceRestriction><saml:Audience>#{audience_uri}</saml:Audience></saml:AudienceRestriction></saml:Conditions>#{attributes_statement}<saml:AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{reference_id}"><saml:AuthnContext><saml:AuthnContextClassRef>urn:federation:authentication:windows</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>]
+        session_expiration = ''
+        if expires_in
+          session_expiration = %{ SessionNotOnOrAfter="#{(now + expires_in).iso8601}"}
+        end
+
+        assertion = %[<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{reference_id}" IssueInstant="#{now.iso8601}" Version="2.0"><saml:Issuer Format="urn:oasis:names:SAML:2.0:nameid-format:entity">#{issuer_uri}</saml:Issuer><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">#{nameID}</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData InResponseTo="#{@saml_request_id}" NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_acs_url}"></saml:SubjectConfirmationData></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}"><saml:AudienceRestriction><saml:Audience>#{audience_uri}</saml:Audience></saml:AudienceRestriction></saml:Conditions>#{attributes_statement}<saml:AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{reference_id}"#{session_expiration}><saml:AuthnContext><saml:AuthnContextClassRef>urn:federation:authentication:windows</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>]
 
         digest_value = Base64.encode64(algorithm.digest(assertion)).gsub(/\n/, '')
 

--- a/ruby-saml-idp.gemspec
+++ b/ruby-saml-idp.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("ruby-saml", "~> 0.8")
   s.add_development_dependency("rails", "~> 3.2")
   s.add_development_dependency("capybara", "~> 2.4.1")
+  s.add_development_dependency("timecop", "~> 0.9.0")
 end
 


### PR DESCRIPTION
Hi,

I'd like add an optional session expiration date. Documentation about that field is available [here](http://www.datypic.com/sc/saml2/a-SessionNotOnOrAfter-1.html). Since it's optional, this PR doesn't break the API.

Best,
David