### PR TITLE
Add license to gemspec

### DIFF
--- a/ruby-saml-idp.gemspec
+++ b/ruby-saml-idp.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/lawrencepit/ruby-saml-idp}
   s.summary = %q{SAML Indentity Provider in ruby}
   s.description = %q{SAML IdP (Identity Provider) library in ruby}
+  s.license = "MIT"
+  
   s.date = Time.now.utc.strftime("%Y-%m-%d")
   s.files = Dir.glob("app/**/*") + Dir.glob("lib/**/*") + [
      "MIT-LICENSE",


### PR DESCRIPTION
I noticed this was missing while running an automated licensing audit for a project I'm working on that may use this gem.
