### PR TITLE
Bug Fix# unless condition was allowing to enter inside the code. Improved Error message

### DIFF
--- a/app/controllers/saml_idp/idp_controller.rb
+++ b/app/controllers/saml_idp/idp_controller.rb
@@ -18,7 +18,7 @@ module SamlIdp
     end
 
     def create
-      unless params[:email].blank? && params[:password].blank?
+      if !params[:email].blank? && !params[:password].blank?
         person = idp_authenticate(params[:email], params[:password])
         if person.nil?
           @saml_idp_fail_msg = "Incorrect email or password."
@@ -27,6 +27,8 @@ module SamlIdp
           render :template => "saml_idp/idp/saml_post", :layout => false
           return
         end
+      else
+        @saml_idp_fail_msg = "Please enter your email and password."
       end
       render :template => "saml_idp/idp/new"
     end


### PR DESCRIPTION
unless condition was allowing to enter inside the code and trying to authenticate even if I left one of the field blank ( email or password ).

2.1.0 :070 > params[:email]=""
 => "" 
2.1.0 :071 > params[:password]="12345678"
 => "12345678" 
2.1.0 :072 > params[:email].blank? && params[:password].blank?
 => false 

So you can see that email is blank and the condition is returning false thats why 'unless' allowing  to enter inside the code and trying to authenticate even one parameter is blank.

I have added one more validation message for the case if we left anything blank 'Please enter your email and password.'