### PR TITLE
Amended Rails version check

### DIFF
--- a/lib/ruby-saml-idp.rb
+++ b/lib/ruby-saml-idp.rb
@@ -3,7 +3,7 @@ module SamlIdp
   require 'saml_idp/controller'
   require 'saml_idp/default'
   require 'saml_idp/version'
-  require 'saml_idp/engine' if defined?(::Rails) && Rails::VERSION::MAJOR > 2
+  require 'saml_idp/engine' if defined?(::Rails::VERSION) && Rails::VERSION::MAJOR > 2
 
   def self.config=(config)
     @config = config


### PR DESCRIPTION
Protecting against case where Rails module has been loaded into non-Rails project, as this can define the module without provising `::Rails::VERSION`.